### PR TITLE
Add plugin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
           path: .cache
 
       - run: pip install mkdocs-material 
+      - run: pip install mdx-truly-sane-lists
       - run: pip install mkdocs-git-committers-plugin-2
 
       - run: mkdocs gh-deploy --force

--- a/docs/javascripts/mathjax,js
+++ b/docs/javascripts/mathjax,js
@@ -1,0 +1,16 @@
+window.MathJax = {
+  tex: {
+    inlineMath: [["\\(", "\\)"]],
+    displayMath: [["\\[", "\\]"]],
+    processEscapes: true,
+    processEnvironments: true,
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex",
+  },
+};
+
+document$.subscribe(() => {
+  MathJax.typesetPromise();
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,8 +107,28 @@ markdown_extensions:
   - pymdownx.caret #下划线
   - pymdownx.mark #文本高亮
   - pymdownx.tilde #删除线
+  - pymdownx.highlight: # 代码块语法高亮
+      anchor_linenums: true # 启用行号
+      line_spans: __span # 自定义行范围
+      pygments_lang_class: true # 使用语言类名
+  - pymdownx.inlinehilite # 行内代码高亮
+  - pymdownx.snippets #代码片段, 没用过, 抄的配置
+  - pymdownx.superfences #代码块增强
+  - pymdownx.arithmatex: # latex
+      generic: true
   - toc: # 大纲
       permalink: true
+      baselevel: 2 # 将大纲的基本级别设置为2(#会变为<h2>)
+  - def_list # 列表
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - mdx_truly_sane_lists # 多级列表
+
+# latex
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 plugins:
   - search

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,8 @@ site_description: "molihua-SOSD的知识分享平台"
 repo_name: Fzu-SOSD-Lab/molihua
 repo_url: https://github.com/Fzu-SOSD-Lab/molihua
 
+use_directory_urls: false # 不使用目录URL
+
 nav:
   - "molihua": index.md
   - 关于我们: about.md


### PR DESCRIPTION
添加插件, 拓展功能包括
- 多层级列表
- ````c` 风格的代码块支持
- latex渲染

修改配置`use_directory_urls: false # 不使用目录URL`
- 能够使得未来在使用html标签(如`<img>`)时, 引用的文件路径不出错(虽然可以让大家强制使用`![]()`)
- 代价是原本文章显示url会从`sampleBlog`->`sampleBlog.html`